### PR TITLE
Update broken download link

### DIFF
--- a/building/index.html
+++ b/building/index.html
@@ -53,7 +53,7 @@
             <h1 class="content-head is-center">Building RyujiNX and Latest Downloads</h1>
             <p>Automatically Compiled builds:</p> 
 			 <p>
-               <a href="https://ci.appveyor.com/api/projects/gdkchan/ryujinx/artifacts/ryujinx_lastest_unstable.zip" class="pure-button pure-button-primary-fit">
+               <a href="https://ci.appveyor.com/api/projects/gdkchan/ryujinx/artifacts/ryujinx_latest_unstable.zip" class="pure-button pure-button-primary-fit">
                Download for Windows
 			   </br><img src="https://camo.githubusercontent.com/ab3840cd63655c5050919461c83e9de51e6dd6f1/68747470733a2f2f63692e6170707665796f722e636f6d2f6170692f70726f6a656374732f7374617475732f737367346a7775367665336b353934733f7376673d74727565" width="70%" height="30%"</img></p></a></p>
 			<!-- <p>


### PR DESCRIPTION
This fixes the broken link for downloading the latest compiled builds for Windows.

Solves #1.